### PR TITLE
Changed LDFLAGS to LDLIBS - g++ can mislink SDL if -lsdl comes before…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CC=g++
 CXX=g++
 CPPFLAGS = -Wall -Wextra $(DEFS) -Wno-clobbered
 CXXFLAGS = -std=c++14 -Ofast -march=native
-LDFLAGS  = -pthread $(shell pkg-config sdl --libs)
+LDLIBS  = -pthread $(shell pkg-config sdl --libs)
 CPPFLAGS +=         $(shell pkg-config sdl --cflags --libs)
 
 BINARIES = \
@@ -21,7 +21,7 @@ BINARIES = \
 	\
 	mandelbrot-vanilla \
 	\
-	
+
 
 all: $(BINARIES)
 


### PR DESCRIPTION
When trying to build your example (which is excellent btw), I was getting link errors on SDL:

```
g++ -std=c++14 -Ofast -march=native -Wall -Wextra -DMAXITER=8000 -DESCAPE_RADIUS_SQUARED=6*6 -Wno-clobbered -D_GNU_SOURCE=1 -D_REENTRANT -I/usr/include/SDL -DPROG_NAME="\"implicit-simd\"" -pthread -lSDL  mandelbrot-implicit-simd.cc   -o mandelbrot-implicit-simd
mandelbrot-implicit-simd.cc: In instantiation of ‘std::array<double, N> plog2(const std::array<double, N>&) [with long unsigned int N = 8ul]’:
mandelbrot-implicit-simd.cc:83:19:   required from ‘std::array<double, N> Iterate(const double*, const std::array<double, N>&) [with bool WithMoment = true; unsigned int N = 8u]’
mandelbrot-implicit-simd.cc:124:57:   required from here
mandelbrot-implicit-simd.cc:9:77: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     std::uint64_t half_bits    = reinterpret_cast<const std::uint64_t&>(half);
                                                                             ^
/tmp/ccGtzT2f.o: In function `std::thread::_Impl<std::_Bind_simple<Display::Display()::{lambda()#1} ()> >::_M_run()':
mandelbrot-implicit-simd.cc:(.text._ZNSt6thread5_ImplISt12_Bind_simpleIFZN7DisplayC4EvEUlvE_vEEE6_M_runEv[_ZNSt6thread5_ImplISt12_Bind_simpleIFZN7DisplayC4EvEUlvE_vEEE6_M_runEv]+0x2c): undefined reference to `SDL_Flip'
/tmp/ccGtzT2f.o: In function `_GLOBAL__sub_I__Z7GetTimev':
mandelbrot-implicit-simd.cc:(.text.startup+0x717): undefined reference to `SDL_SetVideoMode'
```

Looking closely, it's because `-lSDL` is before `mandelbrot-implicit-simd.cc`, so the link's happening at the wrong time (at least with g++ 5.4.0). I don't know a lot about `gcc` or `g++` but [this](https://stackoverflow.com/questions/11893996/why-does-the-order-of-l-option-in-gcc-matter) stackoverflow post indicates that libraries need to be added after their use. I then found [this](https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_10.html) guide on Makefile intrinsics (again, I'm not a C++/C coder) that indicates that LDLIBS is added *after* the input wheras LDFLAGS comes before.

I changed those two around and your examples now compile on my machine just fine. Even if you think this pull sucks, thanks a lot for these videos. I usually code in high-level languages but your videos have inspired me to play around in the lower levels much more.